### PR TITLE
Improve disk selection

### DIFF
--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -5,7 +5,7 @@
 ## to be usable in VMWare. Supposedly it's not always required, but better safe than sorry.
 ## The image should be thinned back out once we do the storage vmotion anyways.
   - name: Convert disk from RAW to VMDK
-    shell: "/usr/bin/qemu-img convert -f raw -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.storage_domains[0].id}}/images/{{item.id}}/{{item.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
+    shell: "/usr/bin/qemu-img convert -f raw -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
     delegate_to: "{{ groups['rhvhost'][0] }}"
 ## Async allowed up to 1 hour, might need to be manually increased for larger images.
     async: 7200

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,9 +116,6 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            # fetch_nested: yes
-            # nested_attributes:
-            #   - disk_attachments
             follows:
               - disk_attachments.disk
           register: rhv_vm
@@ -217,7 +214,7 @@
 
       - name: Convert and Attach disks to target VM
         include_tasks: fragments/convert_and_import_disk.yml
-        loop: "{{rhv_vm_disk_info}}"
+        loop: "{{rhv_vm.ovirt_vms[0].disk_attachments}}"
         loop_control:
           label: "{{item.id}}"
           index_var: loop_index

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,7 +116,8 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            follow: ['disk_attachments','nics']
+            follow: 
+              - disk_attachments.disk
             next_run: true
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,7 +116,7 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            follow: ['disk_attachments.id', 'nics']
+            follow: ['disk_attachments.id']
             next_run: true
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,10 +116,11 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            fetch_nested: yes
-            nested_attributes:
-              - disk_attachments
-            next_run: true
+            # fetch_nested: yes
+            # nested_attributes:
+            #   - disk_attachments
+            follows:
+              - disk_attachments.disk
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"
 

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -130,12 +130,6 @@
               - vnic_profiles
           register: rhv_vm_nics
 
-        - ovirt.ovirt.ovirt_disk_info:
-            auth: "{{ ovirt_auth }}"
-            pattern: "{{ rhv_vm.ovirt_vms[0].name }}"
-          register: rhv_vm_disks
-        - set_fact: rhv_vm_disk_info="{{rhv_vm_disks.ovirt_disks}}"
-
 ## All this, just to get the datacenter ID, which should've just been included in the VM response
         - ovirt.ovirt.ovirt_cluster_info:
             auth: "{{ ovirt_auth }}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,7 +116,7 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            follow: ['disk_attachments.id']
+            follow: ['disk_attachments']
             next_run: true
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -120,6 +120,10 @@
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"
 
+        - name: Debug - RHV VM info
+          debug:
+            var: rhv_vm
+
         - ovirt.ovirt.ovirt_nic_info:
             auth: "{{ ovirt_auth }}"
             vm: "{{ rhv_vm.ovirt_vms[0].name }}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,13 +116,10 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
+            follow: ['disk_attachments.id', 'nics']
             next_run: true
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"
-
-        - name: Debug - RHV VM info
-          debug:
-            var: rhv_vm
 
         - ovirt.ovirt.ovirt_nic_info:
             auth: "{{ ovirt_auth }}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,7 +116,7 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            follow: ['disk_attachments']
+            follow: ['disk_attachments','nics']
             next_run: true
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -116,8 +116,9 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            follow: 
-              - disk_attachments.disk
+            fetch_nested: yes
+            nested_attributes:
+              - disk_attachments
             next_run: true
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"

--- a/migrator.yml
+++ b/migrator.yml
@@ -73,7 +73,8 @@
         - ovirt.ovirt.ovirt_vm_info:
             auth: "{{ ovirt_auth }}"
             pattern: "{{ inventory_hostname }}"
-            next_run: true
+            follows:
+              - disk_attachments.disk
           register: rhv_vm
         - set_fact: vm_name="{{rhv_vm.ovirt_vms[0].name}}"
 

--- a/migrator.yml
+++ b/migrator.yml
@@ -87,12 +87,6 @@
               - vnic_profiles
           register: rhv_vm_nics
 
-        - ovirt.ovirt.ovirt_disk_info:
-            auth: "{{ ovirt_auth }}"
-            pattern: "{{ rhv_vm.ovirt_vms[0].name }}"
-          register: rhv_vm_disks
-        - set_fact: rhv_vm_disk_info="{{rhv_vm_disks.ovirt_disks}}"
-
 ## All this, just to get the datacenter ID, which should've just been included in the VM response
         - ovirt.ovirt.ovirt_cluster_info:
             auth: "{{ ovirt_auth }}"


### PR DESCRIPTION
This PR improves how disks are identified and migrated by using the "follows" param to load the disks when fetching the base VM info, rather than attempting to perform a search for the disks after the fact. This ensures that the appropriate disks are being selected, as with the search method, incorrect disks were occasionally being added when there were similarly named VMs.