### PR TITLE
Autodetect source image format

### DIFF
--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -4,14 +4,24 @@
 ## "-pre" is suffixed here to indicate that it's pre-inflation. In testing, the inflation is required
 ## to be usable in VMWare. Supposedly it's not always required, but better safe than sorry.
 ## The image should be thinned back out once we do the storage vmotion anyways.
-  - name: Debug disk image path
+
+  - name: Collect info about source image
+    ansible.builtin.shell: "qemu-img info --output json /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}}"
+    delegate_to: "{{ groups['rhvhost'][0] }}"
+    register: source_qemu_image_info
+## Output is JSON by default. This might not actually matter.
+  - set_fact: source_qemu_image_info_yaml="{{ source_qemu_image_info | to_yaml }}"
+
+  - name: Debug pre-conversion
     debug:
       msg: 
         - "Processing image: /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}}"
         - "Output image: /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
+        - "Source QEMU Image Info: {{ source_qemu_image_info }}"
+
 
   - name: Convert disk from RAW to VMDK
-    shell: "time /usr/bin/qemu-img convert -f raw -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
+    shell: "/usr/bin/qemu-img convert -f {{ source_qemu_image_info_yaml.format }} -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
     delegate_to: "{{ groups['rhvhost'][0] }}"
 ## Async allowed up to 1 hour, might need to be manually increased for larger images.
     async: 7200
@@ -45,7 +55,7 @@
   - name: Show migration stage 1 diagnostic info
     debug:
       msg:
-        - "Real time taken to perform RAW to VMDK disk conversion: {{ async_conversion_result.stderr_lines[1] }}"
+        - "Real time taken to perform RAW to VMDK disk conversion: {{ async_conversion_result.delta }}"
         - "Original RAW image size (KB): {{ disk_raw_stats.stat.size / 1024 }}"
         - "Pre-Inflation VMDK image size (KB): {{ disk_pre_vmdk_stats.stat.size / 1024 }}"
 

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -10,14 +10,14 @@
     delegate_to: "{{ groups['rhvhost'][0] }}"
     register: source_qemu_image_info
 ## Output is JSON by default. This might not actually matter.
-  - set_fact: source_qemu_image_info_yaml="{{ source_qemu_image_info.stdout | trim | to_yaml }}"
+  - set_fact: source_qemu_image_info="{{ source_qemu_image_info.stdout | trim | from_json }}"
 
   - name: Debug pre-conversion
     debug:
       msg: 
         - "Processing image: /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}}"
         - "Output image: /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
-        - "Source QEMU Image Info: {{ source_qemu_image_info.stdout }}"
+        - "Source QEMU Image Info: {{ source_qemu_image_info }}"
 
   - name: Convert disk from RAW to VMDK
     shell: "/usr/bin/qemu-img convert -f {{ source_qemu_image_info_yaml.format }} -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -27,8 +27,11 @@
     poll: 0
     register: async_conversion
 
-  - name: Poll image conversion process
-    include_tasks: fragments/poll_image_conversion_process.yml
+  - name: Check on disk conversion process
+    async_status:
+      jid: "{{ async_conversion.ansible_job_id }}"
+    delegate_to: "{{ groups['rhvhost'][0] }}"
+    register: async_conversion_result
     until: async_conversion_result.finished
 ## Should keep checking for up to an hour, check every 30 seconds
     retries: 240

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -10,15 +10,14 @@
     delegate_to: "{{ groups['rhvhost'][0] }}"
     register: source_qemu_image_info
 ## Output is JSON by default. This might not actually matter.
-  - set_fact: source_qemu_image_info_yaml="{{ source_qemu_image_info | to_yaml }}"
+  - set_fact: source_qemu_image_info_yaml="{{ source_qemu_image_info.stdout | to_yaml }}"
 
   - name: Debug pre-conversion
     debug:
       msg: 
         - "Processing image: /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}}"
         - "Output image: /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
-        - "Source QEMU Image Info: {{ source_qemu_image_info }}"
-
+        - "Source QEMU Image Info: {{ source_qemu_image_info.stdout }}"
 
   - name: Convert disk from RAW to VMDK
     shell: "/usr/bin/qemu-img convert -f {{ source_qemu_image_info_yaml.format }} -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -27,11 +27,8 @@
     poll: 0
     register: async_conversion
 
-  - name: Check on disk conversion process
-    async_status:
-      jid: "{{ async_conversion.ansible_job_id }}"
-    delegate_to: "{{ groups['rhvhost'][0] }}"
-    register: async_conversion_result
+  - name: Poll image conversion process
+    include_tasks: fragments/poll_image_conversion_process.yml
     until: async_conversion_result.finished
 ## Should keep checking for up to an hour, check every 30 seconds
     retries: 240

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -10,7 +10,7 @@
     delegate_to: "{{ groups['rhvhost'][0] }}"
     register: source_qemu_image_info
 ## Output is JSON by default. This might not actually matter.
-  - set_fact: source_qemu_image_info_yaml="{{ source_qemu_image_info.stdout | to_yaml }}"
+  - set_fact: source_qemu_image_info_yaml="{{ source_qemu_image_info.stdout | trim | to_yaml }}"
 
   - name: Debug pre-conversion
     debug:

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -9,7 +9,6 @@
     ansible.builtin.shell: "qemu-img info --output json /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}}"
     delegate_to: "{{ groups['rhvhost'][0] }}"
     register: source_qemu_image_info
-## Output is JSON by default. This might not actually matter.
   - set_fact: source_qemu_image_info="{{ source_qemu_image_info.stdout | trim | from_json }}"
 
   - name: Debug pre-conversion

--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -20,7 +20,7 @@
         - "Source QEMU Image Info: {{ source_qemu_image_info }}"
 
   - name: Convert disk from RAW to VMDK
-    shell: "/usr/bin/qemu-img convert -f {{ source_qemu_image_info_yaml.format }} -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
+    shell: "/usr/bin/qemu-img convert -f {{ source_qemu_image_info.format }} -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
     delegate_to: "{{ groups['rhvhost'][0] }}"
 ## Async allowed up to 1 hour, might need to be manually increased for larger images.
     async: 7200

--- a/fragments/poll_image_conversion_process.yml
+++ b/fragments/poll_image_conversion_process.yml
@@ -1,9 +1,0 @@
-- name: Check on disk conversion process
-  async_status:
-    jid: "{{ async_conversion.ansible_job_id }}"
-  delegate_to: "{{ groups['rhvhost'][0] }}"
-  register: async_conversion_result
-
-- debug:
-    msg:
-      - "Currently converting image {{item.id}}, current progress: {{ async_conversion_result.stdout_lines[-1] }}"

--- a/fragments/poll_image_conversion_process.yml
+++ b/fragments/poll_image_conversion_process.yml
@@ -1,0 +1,9 @@
+- name: Check on disk conversion process
+  async_status:
+    jid: "{{ async_conversion.ansible_job_id }}"
+  delegate_to: "{{ groups['rhvhost'][0] }}"
+  register: async_conversion_result
+
+- debug:
+    msg:
+      - "Currently converting image {{item.id}}, current progress: {{ async_conversion_result.stdout_lines[-1] }}"


### PR DESCRIPTION
Previously, the source QEMU image format was hardcoded to "raw". This caused issues for one of our VMs (so far) that was set to use the "qcow2" image format. This change adds a new task to run "qemu-img info" against the source image in order to discover its actual format, and then uses that in the subsequent conversion command