### PR TITLE
Sort disks by alias

### DIFF
--- a/fragments/convert_and_import_disk.yml
+++ b/fragments/convert_and_import_disk.yml
@@ -17,6 +17,7 @@
         - "Processing image: /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}}"
         - "Output image: /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"
         - "Source QEMU Image Info: {{ source_qemu_image_info }}"
+        - "Image Alias: {{ item.disk.alias }}"
 
   - name: Convert disk from RAW to VMDK
     shell: "/usr/bin/qemu-img convert -f {{ source_qemu_image_info.format }} -O vmdk -o adapter_type=lsilogic,subformat=streamOptimized,compat6 -p /rhev/data-center/{{rhv_vm_datacenter_id}}/{{item.disk.storage_domains[0].id}}/images/{{item.id}}/{{item.disk.image_id}} /mnt/vmware_migration/{{vm_name}}-disk{{loop_index}}-pre.vmdk"

--- a/migrator-awx.yml
+++ b/migrator-awx.yml
@@ -189,7 +189,7 @@
 
       - name: Convert and Attach disks to target VM
         include_tasks: fragments/convert_and_import_disk.yml
-        loop: "{{rhv_vm.ovirt_vms[0].disk_attachments}}"
+        loop: "{{rhv_vm.ovirt_vms[0].disk_attachments | sort(attribute='disk.alias')}}"
         loop_control:
           label: "{{item.id}}"
           index_var: loop_index


### PR DESCRIPTION
This will hopefully resolve the case where the RHV API returns the incorrect order of disks. This depends on the admin setting an alias that can be properly sequentially sorted